### PR TITLE
Add Metamask support

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -8,12 +8,14 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
+    "metamask-react": "^2.4.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.6.6",
     "react-scripts": "4.0.3",
     "swr": "^0.5.6",
-    "web-vitals": "^1.0.1"
+    "web-vitals": "^1.0.1",
+    "web3": "^1.7.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>BGL-WBGL Bridge</title>
+    <title>%REACT_APP_TITLE%</title>
   </head>
   <body style="height: 100%">
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/app/src/assets/abi/WBGL.json
+++ b/app/src/assets/abi/WBGL.json
@@ -1,0 +1,652 @@
+[
+    {
+        "inputs": [],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+            }
+        ],
+        "name": "Approval",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "approve",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "burn",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "burnFrom",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "subtractedValue",
+                "type": "uint256"
+            }
+        ],
+        "name": "decreaseAllowance",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "grantRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "addedValue",
+                "type": "uint256"
+            }
+        ],
+        "name": "increaseAllowance",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "mint",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "pause",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "Paused",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "renounceRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "revokeRole",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "previousAdminRole",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "newAdminRole",
+                "type": "bytes32"
+            }
+        ],
+        "name": "RoleAdminChanged",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "RoleGranted",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "RoleRevoked",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "transfer",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+            }
+        ],
+        "name": "Transfer",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "transferFrom",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "unpause",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "Unpaused",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "spender",
+                "type": "address"
+            }
+        ],
+        "name": "allowance",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "balanceOf",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "decimals",
+        "outputs": [
+            {
+                "internalType": "uint8",
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "DEFAULT_ADMIN_ROLE",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            }
+        ],
+        "name": "getRoleAdmin",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "uint256",
+                "name": "index",
+                "type": "uint256"
+            }
+        ],
+        "name": "getRoleMember",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            }
+        ],
+        "name": "getRoleMemberCount",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "role",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
+        ],
+        "name": "hasRole",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "MINTER_ROLE",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "name",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "paused",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "PAUSER_ROLE",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "interfaceId",
+                "type": "bytes4"
+            }
+        ],
+        "name": "supportsInterface",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "symbol",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "totalSupply",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    }
+]

--- a/app/src/components/BglToWbgl.js
+++ b/app/src/components/BglToWbgl.js
@@ -2,6 +2,7 @@ import {useState, Fragment} from 'react'
 import {useForm} from 'react-hook-form'
 import {Box, Button, FormControlLabel, FormLabel, Radio, RadioGroup, TextField, Typography} from '@material-ui/core'
 import {post, url, chainLabel} from '../utils'
+import CheckWalletConnection from './CheckWalletConnection'
 
 function BglToWbgl() {
   const {register, handleSubmit, setError, setFocus, formState: {errors}} = useForm()
@@ -30,26 +31,28 @@ function BglToWbgl() {
   }
 
   return !sendAddress ? (
-    <form onSubmit={handleSubmit(onSubmit)} noValidate autoComplete="off">
-      <FormLabel>Chain:</FormLabel>
-      <RadioGroup defaultValue="eth" name="chain" {...register('chain')} onChange={onChangeChain}>
-        <FormControlLabel value="eth" control={<Radio />} label={'Ethereum'} />
-        <FormControlLabel value="bsc" control={<Radio />} label={'Binance Smart Chain'} />
-      </RadioGroup>
-      <TextField
-        variant="filled"
-        margin="normal"
-        label={`${chainLabel(chain)} Address`}
-        fullWidth
-        required
-        helperText={errors.address ? `Please enter a valid ${chainLabel(chain)} address.` : `Enter the ${chainLabel(chain)} address to receive WBGL tokens at.`}
-        {...register('address', {required: true, pattern: /^0x[a-fA-F0-9]{40}$/i})}
-        error={!!errors.address}
-      />
-      <Box display="flex" justifyContent="center" m={1}>
-        <Button type="submit" variant="contained" color="primary" size="large" disabled={submitting}>Continue</Button>
-      </Box>
-    </form>
+    <CheckWalletConnection>
+      <form onSubmit={handleSubmit(onSubmit)} noValidate autoComplete="off">
+        <FormLabel>Chain:</FormLabel>
+        <RadioGroup defaultValue="eth" name="chain" {...register('chain')} onChange={onChangeChain}>
+          <FormControlLabel value="eth" control={<Radio />} label={'Ethereum'} />
+          <FormControlLabel value="bsc" control={<Radio />} label={'Binance Smart Chain'} />
+        </RadioGroup>
+        <TextField
+          variant="filled"
+          margin="normal"
+          label={`${chainLabel(chain)} Address`}
+          fullWidth
+          required
+          helperText={errors.address ? `Please enter a valid ${chainLabel(chain)} address.` : `Enter the ${chainLabel(chain)} address to receive WBGL tokens at.`}
+          {...register('address', {required: true, pattern: /^0x[a-fA-F0-9]{40}$/i})}
+          error={!!errors.address}
+        />
+        <Box display="flex" justifyContent="center" m={1}>
+          <Button type="submit" variant="contained" color="primary" size="large" disabled={submitting}>Continue</Button>
+        </Box>
+      </form>
+    </CheckWalletConnection>
   ) : (
     <Fragment>
       <Typography variant="body1" gutterBottom>Send BGL to: <code>{sendAddress}</code></Typography>

--- a/app/src/components/BglToWbgl.js
+++ b/app/src/components/BglToWbgl.js
@@ -1,20 +1,28 @@
+import {useMetaMask} from 'metamask-react'
 import {useState, Fragment} from 'react'
 import {useForm} from 'react-hook-form'
-import {Box, Button, FormControlLabel, FormLabel, Radio, RadioGroup, TextField, Typography} from '@material-ui/core'
-import {post, url, chainLabel} from '../utils'
+import {
+  Box,
+  Button,
+  List, ListItemText,
+  Typography,
+} from '@material-ui/core'
+import {post, url, chainLabel, isChainBsc} from '../utils'
 import CheckWalletConnection from './CheckWalletConnection'
 
 function BglToWbgl() {
-  const {register, handleSubmit, setError, setFocus, formState: {errors}} = useForm()
+  const {handleSubmit} = useForm()
   const [submitting, setSubmitting] = useState(false)
   const [sendAddress, setSendAddress] = useState(false)
   const [balance, setBalance] = useState(0)
   const [feePercentage, setFeePercentage] = useState(0)
-  const [chain, setChain] = useState('eth')
-  const onChangeChain = event => setChain(event.target.value)
+  const {chainId, account} = useMetaMask()
 
-  const onSubmit = data => {
-    if (!data.chain) data.chain = 'eth'
+  const onSubmit = () => {
+    const data = {
+      chain: isChainBsc(chainId) ? 'bsc' : 'eth',
+      address: account,
+    }
 
     setSubmitting(true)
 
@@ -23,31 +31,17 @@ function BglToWbgl() {
       setBalance(Math.floor(response.balance))
       setFeePercentage(response.feePercentage)
     }).catch(result => {
-      if (result.hasOwnProperty('field')) {
-        setError(result.field, {type: 'manual', message: result.message})
-        setFocus(result.field)
-      }
+      console.error('Error submitting form:', result)
     }).finally(() => setSubmitting(false))
   }
 
   return !sendAddress ? (
     <CheckWalletConnection>
       <form onSubmit={handleSubmit(onSubmit)} noValidate autoComplete="off">
-        <FormLabel>Chain:</FormLabel>
-        <RadioGroup defaultValue="eth" name="chain" {...register('chain')} onChange={onChangeChain}>
-          <FormControlLabel value="eth" control={<Radio />} label={'Ethereum'} />
-          <FormControlLabel value="bsc" control={<Radio />} label={'Binance Smart Chain'} />
-        </RadioGroup>
-        <TextField
-          variant="filled"
-          margin="normal"
-          label={`${chainLabel(chain)} Address`}
-          fullWidth
-          required
-          helperText={errors.address ? `Please enter a valid ${chainLabel(chain)} address.` : `Enter the ${chainLabel(chain)} address to receive WBGL tokens at.`}
-          {...register('address', {required: true, pattern: /^0x[a-fA-F0-9]{40}$/i})}
-          error={!!errors.address}
-        />
+        <List>
+          <ListItemText primary="Chain:" secondary={chainLabel(chainId)}/>
+          <ListItemText primary={`Receiving Address:`} secondary={account}/>
+        </List>
         <Box display="flex" justifyContent="center" m={1}>
           <Button type="submit" variant="contained" color="primary" size="large" disabled={submitting}>Continue</Button>
         </Box>

--- a/app/src/components/CheckWalletConnection.js
+++ b/app/src/components/CheckWalletConnection.js
@@ -1,0 +1,17 @@
+import {useMetaMask} from 'metamask-react'
+import React from 'react'
+import {isChainValid} from '../utils'
+import {isTest} from '../utils/config'
+
+function CheckWalletConnection({children}) {
+  const {status, chainId} = useMetaMask()
+console.log(chainId)
+  if (status !== 'connected') {
+    return 'Please connect wallet.'
+  } else if (!isChainValid(chainId)) {
+    return `Please connect your wallet to either Ethereum ${isTest ? '(Ropsten)' : ''} or Binance Smart Chain ${isTest ? 'Testnet' : 'Mainnet'}.`
+  }
+  return children
+}
+
+export default CheckWalletConnection

--- a/app/src/components/CheckWalletConnection.js
+++ b/app/src/components/CheckWalletConnection.js
@@ -5,7 +5,6 @@ import {isTest} from '../utils/config'
 
 function CheckWalletConnection({children}) {
   const {status, chainId} = useMetaMask()
-console.log(chainId)
   if (status !== 'connected') {
     return 'Please connect wallet.'
   } else if (!isChainValid(chainId)) {

--- a/app/src/components/ConnectWallet.js
+++ b/app/src/components/ConnectWallet.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import {useMetaMask} from 'metamask-react'
+import {Button, Chip} from '@material-ui/core'
+import {chainLabel, isChainValid} from '../utils'
+
+function ConnectWallet() {
+  const {status, chainId, connect} = useMetaMask()
+
+  switch (status) {
+    case 'initializing':
+      return (<div>Synchronizing...</div>)
+
+    case 'unavailable':
+      return (<div>Please install Metamask!</div>)
+
+    case 'notConnected':
+      return (<Button variant="contained" color="secondary" onClick={connect}>Connect</Button>)
+
+    case 'connecting':
+      return (<div>Connecting...</div>)
+
+    case 'connected':
+      return (<Chip label={chainLabel(chainId)} color={isChainValid(chainId) ? 'primary' : 'secondary'}/>)
+  }
+}
+
+export default ConnectWallet

--- a/app/src/components/Header.js
+++ b/app/src/components/Header.js
@@ -3,8 +3,8 @@ import {Box, Container, Link, makeStyles, Typography} from '@material-ui/core'
 import {blueGrey} from '@material-ui/core/colors'
 
 import logo from '../assets/images/logo.png'
-
-const bgColor = blueGrey[700]
+import {appTitle} from '../utils/config'
+import ConnectWallet from './ConnectWallet'
 
 function Header() {
   const classes = useStyles()
@@ -12,22 +12,24 @@ function Header() {
   return (
     <Box p={2} color="white" bgcolor={bgColor} className={classes.container}>
       <Container maxWidth="sm">
-        <Typography variant="h6">
-          <Link color="inherit" underline="none" href="https://bitcointalk.org/index.php?topic=5238559" target="_blank">
-            <img src={logo} alt="BGL" className={classes.logo}/> Bitgesell-WBGL Bridge
-          </Link>
-        </Typography>
+        <Box display="flex" alignItems="center" justifyContent="space-between">
+          <Typography variant="h6">
+            <Link color="inherit" underline="none" href="https://bitcointalk.org/index.php?topic=5238559" target="_blank">
+              <img src={logo} alt="BGL" className={classes.logo}/> {appTitle}
+            </Link>
+          </Typography>
+          <ConnectWallet/>
+        </Box>
       </Container>
     </Box>
   )
 }
 
-const useStyles = makeStyles(theme => ({
-  container: {
+const bgColor = blueGrey[700]
 
-  },
+const useStyles = makeStyles(theme => ({
+  container: {},
   logo: {
-    //display: 'inline-block',
     marginLeft: 10,
     marginRight: 5,
     height: 33,

--- a/app/src/components/WbglToBgl.js
+++ b/app/src/components/WbglToBgl.js
@@ -24,11 +24,23 @@ function WbglToBgl() {
   const AddressForm = () => {
     const {register, handleSubmit, setError, setFocus, formState: {errors}} = useForm()
 
-    const onSubmit = data => {
+    const onSubmit = async data => {
+      setSubmitting(true)
+
       data.chain = chain
       data.ethAddress = account
-
-      setSubmitting(true)
+      try {
+        data.signature = await ethereum.request({
+          method: 'personal_sign',
+          params: [
+            data.bglAddress,
+            account,
+          ],
+        })
+      } catch (e) {
+        setSubmitting(false)
+        return
+      }
 
       post(url('/submit/wbgl'), data).then(response => {
         setSendAddress(response.address)

--- a/app/src/components/WbglToBgl.js
+++ b/app/src/components/WbglToBgl.js
@@ -2,6 +2,7 @@ import {Fragment, useState} from 'react'
 import {useForm} from 'react-hook-form'
 import {Box, Button, FormControlLabel, FormLabel, Radio, RadioGroup, TextField, Typography} from '@material-ui/core'
 import {chainLabel, post, url} from '../utils'
+import CheckWalletConnection from './CheckWalletConnection'
 
 function WbglToBgl() {
   const {register, handleSubmit, getValues, setError, setFocus, formState: {errors}} = useForm()
@@ -53,47 +54,49 @@ function WbglToBgl() {
   const signatureHelperText = `Sign your BGL address with your ${chainLabel(chain)} wallet's private key and paste the result here. You can sign your address here: https://app.mycrypto.com/sign-message`
 
   return !sendAddress ? (
-    <form onSubmit={handleSubmit(onSubmit)} noValidate autoComplete="off">
-      <FormLabel>Chain:</FormLabel>
-      <RadioGroup defaultValue="eth" name="chain" {...register('chain')} onChange={onChangeChain}>
-        <FormControlLabel value="eth" control={<Radio />} label={'Ethereum'} />
-        <FormControlLabel value="bsc" control={<Radio />} label={'Binance Smart Chain'} />
-      </RadioGroup>
-      <TextField
-        variant="filled"
-        margin="normal"
-        label={`${chainLabel(chain)} Address`}
-        fullWidth
-        required
-        helperText={errors['ethAddress'] ? `Please enter a valid ${chainLabel(chain)} address.` : `Enter the ${chainLabel(chain)} address you will be sending WBGL tokens from.`}
-        {...register('ethAddress', {required: true, pattern: /^0x[a-fA-F0-9]{40}$/i})}
-        error={!!errors['ethAddress']}
-      />
-      <TextField
-        variant="filled"
-        margin="normal"
-        label="BGL Address"
-        fullWidth
-        required
-        helperText={errors['bglAddress'] ? 'Please enter a valid Bitgesell address.' : 'Enter the BGL address coins will be sent to.'}
-        {...register('bglAddress', {required: true, pattern: /^(bgl1|[135])[a-zA-HJ-NP-Z0-9]{25,39}$/i})}
-        error={!!errors['bglAddress']}
-      />
-      <TextField
-        variant="filled"
-        margin="normal"
-        label="Signed BGL address"
-        fullWidth
-        required
-        multiline
-        helperText={signatureHelperText + (errors['signature'] ? ' Please enter a valid signature.' : '')}
-        {...register('signature', {required: true, validate: validateSignature})}
-        error={!!errors['signature']}
-      />
-      <Box display="flex" justifyContent="center" m={1}>
-        <Button type="submit" variant="contained" color="primary" size="large" disabled={submitting}>Continue</Button>
-      </Box>
-    </form>
+    <CheckWalletConnection>
+      <form onSubmit={handleSubmit(onSubmit)} noValidate autoComplete="off">
+        <FormLabel>Chain:</FormLabel>
+        <RadioGroup defaultValue="eth" name="chain" {...register('chain')} onChange={onChangeChain}>
+          <FormControlLabel value="eth" control={<Radio />} label={'Ethereum'} />
+          <FormControlLabel value="bsc" control={<Radio />} label={'Binance Smart Chain'} />
+        </RadioGroup>
+        <TextField
+          variant="filled"
+          margin="normal"
+          label={`${chainLabel(chain)} Address`}
+          fullWidth
+          required
+          helperText={errors['ethAddress'] ? `Please enter a valid ${chainLabel(chain)} address.` : `Enter the ${chainLabel(chain)} address you will be sending WBGL tokens from.`}
+          {...register('ethAddress', {required: true, pattern: /^0x[a-fA-F0-9]{40}$/i})}
+          error={!!errors['ethAddress']}
+        />
+        <TextField
+          variant="filled"
+          margin="normal"
+          label="BGL Address"
+          fullWidth
+          required
+          helperText={errors['bglAddress'] ? 'Please enter a valid Bitgesell address.' : 'Enter the BGL address coins will be sent to.'}
+          {...register('bglAddress', {required: true, pattern: /^(bgl1|[135])[a-zA-HJ-NP-Z0-9]{25,39}$/i})}
+          error={!!errors['bglAddress']}
+        />
+        <TextField
+          variant="filled"
+          margin="normal"
+          label="Signed BGL address"
+          fullWidth
+          required
+          multiline
+          helperText={signatureHelperText + (errors['signature'] ? ' Please enter a valid signature.' : '')}
+          {...register('signature', {required: true, validate: validateSignature})}
+          error={!!errors['signature']}
+        />
+        <Box display="flex" justifyContent="center" m={1}>
+          <Button type="submit" variant="contained" color="primary" size="large" disabled={submitting}>Continue</Button>
+        </Box>
+      </form>
+    </CheckWalletConnection>
   ) : (
     <Fragment>
       <Typography variant="body1" gutterBottom>Send WBGL tokens to: <code>{sendAddress}</code></Typography>

--- a/app/src/components/WbglToBgl.js
+++ b/app/src/components/WbglToBgl.js
@@ -1,76 +1,49 @@
 import {Fragment, useState} from 'react'
+import {useMetaMask} from 'metamask-react'
 import {useForm} from 'react-hook-form'
-import {Box, Button, FormControlLabel, FormLabel, Radio, RadioGroup, TextField, Typography} from '@material-ui/core'
-import {chainLabel, post, url} from '../utils'
+import {
+  Box,
+  Button,
+  List, ListItemText,
+  TextField,
+  Typography,
+} from '@material-ui/core'
+import {chainLabel, isChainBsc, post, url} from '../utils'
+import {sendWbgl, useWbglBalance} from '../utils/wallet'
 import CheckWalletConnection from './CheckWalletConnection'
 
 function WbglToBgl() {
-  const {register, handleSubmit, getValues, setError, setFocus, formState: {errors}} = useForm()
   const [submitting, setSubmitting] = useState(false)
   const [sendAddress, setSendAddress] = useState('')
   const [balance, setBalance] = useState(0)
   const [feePercentage, setFeePercentage] = useState(0)
-  const [chain, setChain] = useState('eth')
-  const onChangeChain = event => setChain(event.target.value)
+  const wbglBalance = useWbglBalance()
+  const {chainId, account, ethereum} = useMetaMask()
+  const chain = isChainBsc(chainId) ? 'bsc' : 'eth'
 
-  const signatureObject = signature => /^0x[0-9a-f]+$/.test(signature) ? {
-    address: getValues('ethAddress'),
-    msg: getValues('bglAddress'),
-    sig: signature,
-  } : JSON.parse(signature)
+  const AddressForm = () => {
+    const {register, handleSubmit, setError, setFocus, formState: {errors}} = useForm()
 
-  const validateSignature = value => {
-    try {
-      const signature = signatureObject(value)
-      if (typeof signature === 'object' && signature !== null) {
-        if (signature.hasOwnProperty('address') && signature.hasOwnProperty('msg') && signature.hasOwnProperty('sig')) {
-          if (signature.address === getValues('ethAddress') && signature.msg === getValues('bglAddress')) {
-            return true
-          }
+    const onSubmit = data => {
+      data.chain = chain
+      data.ethAddress = account
+
+      setSubmitting(true)
+
+      post(url('/submit/wbgl'), data).then(response => {
+        setSendAddress(response.address)
+        setBalance(Math.floor(response.balance))
+        setFeePercentage(response.feePercentage)
+      }).catch(result => {
+        if (result.hasOwnProperty('field')) {
+          setError(result.field, {type: 'manual', message: result.message})
+          setFocus(result.field)
         }
-      }
-      return false
-    } catch (e) {
-      return false
+      }).finally(() => setSubmitting(false))
     }
-  }
-  const onSubmit = data => {
-    data.chain = chain
-    console.log("data: ", data.chain);
-    //if (!data.chain) data.chain = 'eth'
-    data.signature = signatureObject(data.signature)
 
-    post(url('/submit/wbgl'), data).then(response => {
-      setSendAddress(response.address)
-      setBalance(Math.floor(response.balance))
-      setFeePercentage(response.feePercentage)
-    }).catch(result => {
-      if (result.hasOwnProperty('field')) {
-        setError(result.field, {type: 'manual', message: result.message})
-        setFocus(result.field)
-      }
-    }).finally(() => setSubmitting(false))
-  }
-  const signatureHelperText = `Sign your BGL address with your ${chainLabel(chain)} wallet's private key and paste the result here. You can sign your address here: https://app.mycrypto.com/sign-message`
-
-  return !sendAddress ? (
-    <CheckWalletConnection>
+    return (
       <form onSubmit={handleSubmit(onSubmit)} noValidate autoComplete="off">
-        <FormLabel>Chain:</FormLabel>
-        <RadioGroup defaultValue="eth" name="chain" {...register('chain')} onChange={onChangeChain}>
-          <FormControlLabel value="eth" control={<Radio />} label={'Ethereum'} />
-          <FormControlLabel value="bsc" control={<Radio />} label={'Binance Smart Chain'} />
-        </RadioGroup>
-        <TextField
-          variant="filled"
-          margin="normal"
-          label={`${chainLabel(chain)} Address`}
-          fullWidth
-          required
-          helperText={errors['ethAddress'] ? `Please enter a valid ${chainLabel(chain)} address.` : `Enter the ${chainLabel(chain)} address you will be sending WBGL tokens from.`}
-          {...register('ethAddress', {required: true, pattern: /^0x[a-fA-F0-9]{40}$/i})}
-          error={!!errors['ethAddress']}
-        />
         <TextField
           variant="filled"
           margin="normal"
@@ -81,31 +54,71 @@ function WbglToBgl() {
           {...register('bglAddress', {required: true, pattern: /^(bgl1|[135])[a-zA-HJ-NP-Z0-9]{25,39}$/i})}
           error={!!errors['bglAddress']}
         />
-        <TextField
-          variant="filled"
-          margin="normal"
-          label="Signed BGL address"
-          fullWidth
-          required
-          multiline
-          helperText={signatureHelperText + (errors['signature'] ? ' Please enter a valid signature.' : '')}
-          {...register('signature', {required: true, validate: validateSignature})}
-          error={!!errors['signature']}
-        />
         <Box display="flex" justifyContent="center" m={1}>
           <Button type="submit" variant="contained" color="primary" size="large" disabled={submitting}>Continue</Button>
         </Box>
       </form>
-    </CheckWalletConnection>
-  ) : (
+    )
+  }
+
+  const SendForm = () => {
+    const {register, handleSubmit, setError, formState: {errors}} = useForm()
+
+    const onSubmit = async data => {
+      const amount = parseFloat(data.amount)
+      const balance = parseFloat(wbglBalance)
+
+      if (!amount || !balance || amount > balance) {
+        setError('amount', {type: 'manual', message: 'Not enough WBGL available!', shouldFocus: true})
+        return
+      }
+
+      setSubmitting(true)
+      await sendWbgl(chainId, account, sendAddress, data.amount, ethereum)
+      setSubmitting(false)
+    }
+
+    return (
+      <form onSubmit={handleSubmit(onSubmit)} noValidate autoComplete="off">
+        <TextField
+          variant="filled"
+          margin="normal"
+          label="WBGL Amount"
+          fullWidth
+          required
+          helperText={errors['amount'] ? 'Please enter a valid amount.' : 'Enter the amount of tokens to send.'}
+          {...register('amount', {required: true, pattern: /^[0-9]+\.?[0-9]*$/i})}
+          error={!!errors['amount']}
+        />
+        <Button type="submit" variant="contained" color="primary" size="large" disabled={submitting}>Send WBGL</Button>
+      </form>
+    )
+  }
+
+  return (
     <Fragment>
-      <Typography variant="body1" gutterBottom>Send WBGL tokens to: <code>{sendAddress}</code></Typography>
-      <Typography variant="body2" gutterBottom>
-        The currently available BGL balance is <b>{balance}</b>. If you send more WBGL than is available to complete the exchange, your WBGL will be returned to your address.
-      </Typography>
-      <Typography variant="body2" gutterBottom>
-        Please note, that a fee of <b>{feePercentage}%</b> will be automatically deducted from the transfer amount. This exchange pair is active for <b>7 days</b>.
-      </Typography>
+      <List>
+        <ListItemText primary="Chain:" secondary={chainLabel(chainId)}/>
+        <ListItemText primary={`Source Address:`} secondary={account}/>
+        <ListItemText primary="WBGL Balance:" secondary={wbglBalance}/>
+      </List>
+      {!sendAddress ? (
+        <CheckWalletConnection>
+          <AddressForm/>
+        </CheckWalletConnection>
+      ) : (
+        <Fragment>
+          <Typography variant="body2" gutterBottom>
+            The currently available BGL balance is <b>{balance}</b>. If you send more WBGL than is available to complete
+            the exchange, your WBGL will be returned to your address.
+          </Typography>
+          <Typography variant="body2" gutterBottom>
+            Please note, that a fee of <b>{feePercentage}%</b> will be automatically deducted from the transfer amount.
+          </Typography>
+          <SendForm/>
+        </Fragment>
+      )}
+
     </Fragment>
   )
 }

--- a/app/src/components/WbglToBgl.js
+++ b/app/src/components/WbglToBgl.js
@@ -96,16 +96,14 @@ function WbglToBgl() {
   }
 
   return (
-    <Fragment>
+    <CheckWalletConnection>
       <List>
         <ListItemText primary="Chain:" secondary={chainLabel(chainId)}/>
         <ListItemText primary={`Source Address:`} secondary={account}/>
         <ListItemText primary="WBGL Balance:" secondary={wbglBalance}/>
       </List>
       {!sendAddress ? (
-        <CheckWalletConnection>
-          <AddressForm/>
-        </CheckWalletConnection>
+        <AddressForm/>
       ) : (
         <Fragment>
           <Typography variant="body2" gutterBottom>
@@ -119,7 +117,7 @@ function WbglToBgl() {
         </Fragment>
       )}
 
-    </Fragment>
+    </CheckWalletConnection>
   )
 }
 

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -1,11 +1,14 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import {MetaMaskProvider} from 'metamask-react'
 import App from './components/App'
 import reportWebVitals from './reportWebVitals'
 
 ReactDOM.render(
   <React.StrictMode>
-    <App/>
+    <MetaMaskProvider>
+      <App/>
+    </MetaMaskProvider>
   </React.StrictMode>,
   document.getElementById('root'),
 )

--- a/app/src/utils/config.js
+++ b/app/src/utils/config.js
@@ -1,1 +1,5 @@
+export const appTitle = process.env.REACT_APP_TITLE || 'Bitgesell-WBGL Bridge'
+
 export const serviceUrl = process.env.REACT_APP_SERVICE_URL
+
+export const isTest = process.env.NODE_ENV !== 'production'

--- a/app/src/utils/index.js
+++ b/app/src/utils/index.js
@@ -25,7 +25,7 @@ export function chainLabel(chainId) {
   let chain = chainId
 
   if (!['eth', 'bsc'].includes(chainId)) {
-    chain = (typeof chainId == 'string' ? ['0x38', '0x61'] : [56, 97]).includes(chainId) ? 'bsc' : 'eth'
+    chain = isChainBsc(chainId) ? 'bsc' : 'eth'
   }
 
   return names[chain]
@@ -33,4 +33,14 @@ export function chainLabel(chainId) {
 
 export function isChainValid(chainId) {
   return isTest ? [3, 97, '0x3', '0x61'].includes(chainId) : [1, 56, '0x1', '0x38'].includes(chainId)
+}
+
+export const isChainBsc = chainId => (typeof chainId == 'string' ? ['0x38', '0x61'] : [56, 97]).includes(chainId)
+
+let contracts
+export async function getTokenAddress(chainId) {
+  if (!contracts) {
+    contracts = await (await fetch(url('/contracts'))).json()
+  }
+  return contracts[isChainBsc(chainId) ? 'bsc' : 'eth']
 }

--- a/app/src/utils/index.js
+++ b/app/src/utils/index.js
@@ -1,4 +1,4 @@
-import {serviceUrl} from './config'
+import {isTest, serviceUrl} from './config'
 
 export const url = path => serviceUrl + path
 
@@ -17,10 +17,20 @@ export const post = async (url, data) => {
   return response.json()
 }
 
-export function chainLabel(chain) {
+export function chainLabel(chainId) {
   const names = {
     eth: 'Ethereum',
     bsc: 'Binance Smart Chain',
   }
+  let chain = chainId
+
+  if (!['eth', 'bsc'].includes(chainId)) {
+    chain = (typeof chainId == 'string' ? ['0x38', '0x61'] : [56, 97]).includes(chainId) ? 'bsc' : 'eth'
+  }
+
   return names[chain]
+}
+
+export function isChainValid(chainId) {
+  return isTest ? [3, 97, '0x3', '0x61'].includes(chainId) : [1, 56, '0x1', '0x38'].includes(chainId)
 }

--- a/app/src/utils/wallet.js
+++ b/app/src/utils/wallet.js
@@ -3,7 +3,7 @@ import {useMetaMask} from 'metamask-react'
 import Web3 from 'web3'
 
 import abi from '../assets/abi/WBGL.json'
-import {getTokenAddress} from './index'
+import {getTokenAddress, isChainValid} from './index'
 
 let web3
 let WBGL
@@ -23,20 +23,21 @@ export function useWbglBalance() {
   const fetch = async () => {
     const current = web3.utils.fromWei(await WBGL.methods['balanceOf'](account).call(), 'ether')
     setBalance(current)
-    console.log(current)
   }
 
   useEffect(() => {
-    getTokenAddress(chainId).then(async contractAddress => {
-      const web3 = getWeb3(ethereum)
-      WBGL = new web3.eth.Contract(abi, contractAddress)
+    if (isChainValid(chainId)) {
+      getTokenAddress(chainId).then(async contractAddress => {
+        const web3 = getWeb3(ethereum)
+        WBGL = new web3.eth.Contract(abi, contractAddress)
 
-      await fetch()
+        await fetch()
 
-      interval = setInterval(fetch, 30000)
-    })
+        interval = setInterval(fetch, 30000)
+      })
 
-    return () => clearInterval(interval)
+      return () => clearInterval(interval)
+    }
   }, [])
 
   return balance

--- a/app/src/utils/wallet.js
+++ b/app/src/utils/wallet.js
@@ -1,0 +1,52 @@
+import {useEffect, useState} from 'react'
+import {useMetaMask} from 'metamask-react'
+import Web3 from 'web3'
+
+import abi from '../assets/abi/WBGL.json'
+import {getTokenAddress} from './index'
+
+let web3
+let WBGL
+let interval
+
+export function getWeb3(ethereum) {
+  if (!web3) {
+    web3 = new Web3(ethereum)
+  }
+  return web3
+}
+
+export function useWbglBalance() {
+  const [balance, setBalance] = useState('')
+  const {ethereum, account, chainId} = useMetaMask()
+
+  const fetch = async () => {
+    const current = web3.utils.fromWei(await WBGL.methods['balanceOf'](account).call(), 'ether')
+    setBalance(current)
+    console.log(current)
+  }
+
+  useEffect(() => {
+    getTokenAddress(chainId).then(async contractAddress => {
+      const web3 = getWeb3(ethereum)
+      WBGL = new web3.eth.Contract(abi, contractAddress)
+
+      await fetch()
+
+      interval = setInterval(fetch, 30000)
+    })
+
+    return () => clearInterval(interval)
+  }, [])
+
+  return balance
+}
+
+export async function sendWbgl(chainId, from, to, amount, ethereum) {
+  const web3 = getWeb3(ethereum)
+  const value = web3.utils.toWei(amount, 'ether');
+
+  WBGL = WBGL || new web3.eth.Contract(abi, await getTokenAddress(chainId))
+
+  await WBGL.methods.transfer(to, value).send({from})
+}

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -12,6 +12,7 @@ services:
       - NODE_ENV=development
       - CHOKIDAR_USEPOLLING=true
       - REACT_APP_SERVICE_URL=localhost:8480
+      - REACT_APP_TITLE=Bitgesell-WBGL Bridge
       - SSL=false
     tty: true
     ports:

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -10,10 +10,11 @@ services:
       - service
     environment:
       - NODE_ENV=development
+      - NODE_OPTIONS=--openssl-legacy-provider
       - CHOKIDAR_USEPOLLING=true
-      - REACT_APP_SERVICE_URL=localhost:8480
-      - REACT_APP_TITLE=Bitgesell-WBGL Bridge
       - SSL=false
+      - REACT_APP_SERVICE_URL=http://localhost:8480
+      - REACT_APP_TITLE=Bitgesell-WBGL Bridge
     tty: true
     ports:
       - "8406:19006"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,9 +4,9 @@ RUN apt-get update -y \
     && apt-get install curl ca-certificates apt-transport-https bash perl -y \
     && apt-get clean
 
-RUN curl -L "http://ftp.de.debian.org/debian/pool/main/p/perl/perl-modules-5.30_5.30.3-4_all.deb" -o "/var/tmp/perl-modules-5.30_5.30.3-4_all.deb" \
-    && curl -L "https://github.com/BitgesellOfficial/bitgesell/releases/download/0.1.7/bitgesell_0.1.7_amd64.deb" -o "/var/tmp/bitgesell.deb" \
-    && dpkg -i "/var/tmp/perl-modules-5.30_5.30.3-4_all.deb" \
+RUN curl -L "http://security.ubuntu.com/ubuntu/pool/main/p/perl/perl-modules-5.30_5.30.0-9ubuntu0.2_all.deb" -o "/var/tmp/perl-modules.deb" \
+    && curl -L "https://github.com/BitgesellOfficial/bitgesell/releases/download/0.1.8/bitgesell_0.1.8_amd64.deb" -o "/var/tmp/bitgesell.deb" \
+    && dpkg -i "/var/tmp/perl-modules.deb" \
     && dpkg -i "/var/tmp/bitgesell.deb" \
     && apt-get install -y -f \
     && rm -rf "/var/tmp/*"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update -y \
     && apt-get clean
 
 RUN curl -L "http://security.ubuntu.com/ubuntu/pool/main/p/perl/perl-modules-5.30_5.30.0-9ubuntu0.2_all.deb" -o "/var/tmp/perl-modules.deb" \
-    && curl -L "https://github.com/BitgesellOfficial/bitgesell/releases/download/0.1.8/bitgesell_0.1.8_amd64.deb" -o "/var/tmp/bitgesell.deb" \
+    && curl -L "https://github.com/BitgesellOfficial/bitgesell/releases/download/0.1.7/bitgesell_0.1.7_amd64.deb" -o "/var/tmp/bitgesell.deb" \
     && dpkg -i "/var/tmp/perl-modules.deb" \
     && dpkg -i "/var/tmp/bitgesell.deb" \
     && apt-get install -y -f \

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -9,4 +9,6 @@ WORKDIR /service
 
 COPY . .
 
+RUN yarn install
+
 CMD ["sh", "-c", "yarn ; pm2-runtime src/server.js"]

--- a/service/src/app.js
+++ b/service/src/app.js
@@ -21,6 +21,7 @@ app.use(function(req, res, next) {
 
 app.get("/", IndexController.healthCheck);
 app.get("/state", IndexController.state);
+app.get("/contracts", IndexController.contracts);
 
 app.get("/balance/bgl", BalanceController.bgl);
 app.get("/balance/eth", BalanceController.eth);

--- a/service/src/controllers/IndexController.js
+++ b/service/src/controllers/IndexController.js
@@ -1,4 +1,5 @@
 import { Db, RPC, Eth, Bsc } from "../modules/index.js";
+import { eth, bsc } from "../utils/config.js";
 
 export const healthCheck = async (_req, res) => {
   try {
@@ -51,4 +52,11 @@ export const state = async (_req, res) => {
     console.log(e);
     res.status(500).json({ status: "error", message: "RPC not available" });
   }
+};
+
+export const contracts = async (_req, res) => {
+  res.json({
+    eth: eth.contract,
+    bsc: bsc.contract,
+  });
 };

--- a/service/src/controllers/SubmitController.js
+++ b/service/src/controllers/SubmitController.js
@@ -77,9 +77,32 @@ export const wbglToBgl = async (req, res) => {
       });
       return;
     }
+    if (
+      !data.hasOwnProperty("signature") ||
+      typeof data.signature !== "string"
+    ) {
+      res.status(400).json({
+        status: "error",
+        field: "signature",
+        message: "No signature or malformed signature provided.",
+      });
+      return;
+    }
     const chain =
       data.hasOwnProperty("chain") && data.chain !== "eth" ? "bsc" : "eth";
     console.log("data.chain :", data.chain);
+    const Chain = chain === "eth" ? Eth : Bsc;
+    if (
+      data.ethAddress.toLowerCase() !==
+      Chain.web3.eth.accounts.recover(data.bglAddress, data.signature).toLowerCase()
+    ) {
+      res.status(400).json({
+        status: "error",
+        field: "signature",
+        message: "Signature does not match the address provided.",
+      });
+      return;
+    }
 
     let transfer = await Transfer.findOne({
       type: "wbgl",

--- a/service/src/controllers/SubmitController.js
+++ b/service/src/controllers/SubmitController.js
@@ -77,37 +77,9 @@ export const wbglToBgl = async (req, res) => {
       });
       return;
     }
-    if (
-      !data.hasOwnProperty("signature") ||
-      typeof data.signature !== "object" ||
-      !data.signature.hasOwnProperty("address") ||
-      !data.signature.hasOwnProperty("msg") ||
-      !data.signature.hasOwnProperty("sig") ||
-      data.signature.address !== data.ethAddress ||
-      data.signature.msg !== data.bglAddress
-    ) {
-      res.status(400).json({
-        status: "error",
-        field: "signature",
-        message: "No signature or malformed signature provided.",
-      });
-      return;
-    }
     const chain =
       data.hasOwnProperty("chain") && data.chain !== "eth" ? "bsc" : "eth";
     console.log("data.chain :", data.chain);
-    const Chain = chain === "eth" ? Eth : Bsc;
-    if (
-      data.ethAddress !==
-      Chain.web3.eth.accounts.recover(data.bglAddress, data.signature.sig)
-    ) {
-      res.status(400).json({
-        status: "error",
-        field: "signature",
-        message: "Signature does not match the address provided.",
-      });
-      return;
-    }
 
     let transfer = await Transfer.findOne({
       type: "wbgl",


### PR DESCRIPTION
Refactored frontend application to integrate with Metamask to fetch addresses and make WBGL transfers. Removes a lot of tedium from the bridging process, such as having to enter all addresses manually and generating signatures.

Deployment note: I've added `REACT_APP_TITLE` as an environment variable that contains the app title (used in both HTML title tag as well as app header). This needs to be present when building the production bundle. Also, `NODE_ENV` needs to be set to `production`, otherwise the app will be running on testnet.